### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Integration/Adapter/MercureTest.php
+++ b/tests/Integration/Adapter/MercureTest.php
@@ -69,7 +69,7 @@ class MercureTest extends TestCase
         ];
 
         $this->mockHttpClientInConnection();
-        $this->assertTrue(is_string($this->getMercureAdapter()->publish(['c1'], '', $payload)));
+        $this->assertIsString($this->getMercureAdapter()->publish(['c1'], '', $payload));
     }
 
     public function testAdapterSendsMessageInEventAndDataFormat()

--- a/tests/Integration/Provider/MercureServiceProviderTest.php
+++ b/tests/Integration/Provider/MercureServiceProviderTest.php
@@ -22,9 +22,9 @@ class MercureServiceProviderTest extends TestCase
 {
     public function testServiceProviderBindsComponents()
     {
-        $this->assertTrue(app('mercure') instanceof PublisherInterface);
-        $this->assertTrue(app(PublisherInterface::class) instanceof PublisherInterface);
-        $this->assertTrue(app(Publisher::class) instanceof PublisherInterface);
+        $this->assertInstanceOf(PublisherInterface::class, app('mercure'));
+        $this->assertInstanceOf(PublisherInterface::class, app(PublisherInterface::class));
+        $this->assertInstanceOf(PublisherInterface::class, app(Publisher::class));
     }
 
     public function testUsesDefaultConnectionWhenCreatingInstance()
@@ -52,7 +52,7 @@ class MercureServiceProviderTest extends TestCase
      */
     public function testRegistersNotificationDriverThroughEnvironment()
     {
-        $this->assertTrue(app(ChannelManager::class)->driver('mercure') instanceof MercureChannel);
+        $this->assertInstanceOf(MercureChannel::class, app(ChannelManager::class)->driver('mercure'));
     }
 
     /**
@@ -70,13 +70,13 @@ class MercureServiceProviderTest extends TestCase
      */
     public function testRegistersBroadcastingDriverThroughEnvironment()
     {
-        $this->assertTrue(app(BroadcastManager::class)->driver('mercure') instanceof Broadcaster);
+        $this->assertInstanceOf(Broadcaster::class, app(BroadcastManager::class)->driver('mercure'));
     }
 
     public function testBoundMercureChannelShouldReturnItself()
     {
         $channel = app(MercureChannel::class);
-        $this->assertTrue($channel instanceof MercureChannel);
+        $this->assertInstanceOf(MercureChannel::class, $channel);
     }
 
     /**

--- a/tests/Unit/Factory/PublisherTest.php
+++ b/tests/Unit/Factory/PublisherTest.php
@@ -15,8 +15,8 @@ class PublisherTest extends TestCase
     public function testFactoryShouldReturnPublisherInterface()
     {
         $publisher = Publisher::instance($this->config());
-        $this->assertTrue($publisher instanceof PublisherInterface);
-        $this->assertTrue($publisher instanceof MercurePublisher);
+        $this->assertInstanceOf(PublisherInterface::class, $publisher);
+        $this->assertInstanceOf(MercurePublisher::class, $publisher);
     }
 
     public function testShouldThrowExceptionForNoUrl()


### PR DESCRIPTION
# Changed log

- Using the `assertIsString` to expect type is `string`.
- Using the `assertInstanceOf` to expect is specific class instance.